### PR TITLE
Feature/linebomb Item클래스 생성 방법 변경

### DIFF
--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -15,7 +15,6 @@ public class Item {
     }
 
     public void itemActivate() {
-        if (Math.random() < 0.99) {
             Random random = new Random();
             int randomMethodIndex = random.nextInt(6);
             System.out.println(randomMethodIndex);
@@ -37,8 +36,6 @@ public class Item {
                     isMultiShotActivated = true;
                     break;
             }
-
-        }
     }
 
     public void setIsGhostActive() {

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -3,9 +3,16 @@ package entity;
 import java.util.Random;
 
 public class Item {
-    public boolean isGhostAction = false;
-    public boolean isMultiShotActivated = false;
-    public boolean isLineBombActivated = false;
+
+    public boolean isGhostAction;
+    public boolean isMultiShotActivated;
+    public boolean isLineBombActivated;
+
+    public Item(boolean isGhostAction, boolean isMultiShotActivated, boolean isLineBombActivated) {
+        this.isGhostAction = false;
+        this.isMultiShotActivated = false;
+        this.isLineBombActivated = false;
+    }
 
     public void itemActivate() {
         if (Math.random() < 0.99) {

--- a/src/entity/Item.java
+++ b/src/entity/Item.java
@@ -8,7 +8,7 @@ public class Item {
     public boolean isMultiShotActivated;
     public boolean isLineBombActivated;
 
-    public Item(boolean isGhostAction, boolean isMultiShotActivated, boolean isLineBombActivated) {
+    public Item() {
         this.isGhostAction = false;
         this.isMultiShotActivated = false;
         this.isLineBombActivated = false;

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -307,27 +307,30 @@ public class GameScreen extends Screen {
                             destroyVerticalValue = i;
                             destroyShipHorizonalValue = j;
                             recyclable.add(bullet);
-							item = new Item();
-							dropItem();
-                            if (item.isGhostAction) {
-                                isGhostOn = true;
-                                this.ship.setColor(Color.DARK_GRAY);
-                                new Thread(() -> {
-                                    try {
-                                        Thread.sleep(3000);  // 3초 후 고스트 모드 해제
-                                        isGhostOn = false;
-                                        this.ship.setColor(Color.GREEN);
-                                        item.setIsGhostActive();
-                                    } catch (InterruptedException e) {
-                                        e.printStackTrace();
-                                    }
-                                }).start();
-                            } else if (item.isMultiShotActivated) {
-                                isMultiShotOn = true;
-                            }
-                            else if (item.isLineBombActivated){
-                                operateLineBomb(enemyShip, destroyVerticalValue,destroyShipHorizonalValue, recyclable, bullet);
-                            }
+
+							if(dropItem()){
+								if (item.isGhostAction) {
+									isGhostOn = true;
+									this.ship.setColor(Color.DARK_GRAY);
+									new Thread(() -> {
+										try {
+											Thread.sleep(3000);  // 3초 후 고스트 모드 해제
+											isGhostOn = false;
+											this.ship.setColor(Color.GREEN);
+											item.setIsGhostActive();
+										} catch (InterruptedException e) {
+											e.printStackTrace();
+										}
+									}).start();
+								} else if (item.isMultiShotActivated) {
+									isMultiShotOn = true;
+								}
+								else if (item.isLineBombActivated){
+									operateLineBomb(enemyShip, destroyVerticalValue,destroyShipHorizonalValue, recyclable, bullet);
+								}
+							}else{
+								break;
+							}
                         }
                     }
                 }
@@ -345,10 +348,13 @@ public class GameScreen extends Screen {
 		BulletPool.recycle(recyclable);
 	}
 
-	private void dropItem() {
+	private boolean dropItem() {
 		if(Math.random() < 0.99){
+			item = new Item();
 			item.itemActivate();
+			return true;
 		}
+		return false;
 	}
 
 	private void operateLineBomb(EnemyShip enemyShip, int column, int row , Set<Bullet> recyclable, Bullet bullet) {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -74,6 +74,8 @@ public class GameScreen extends Screen {
 
 	private List<List<EnemyShip>> enemyShips;
 
+	private Item item;
+
     /**
 	 * Constructor, establishes the properties of the screen.
 	 * 
@@ -305,8 +307,8 @@ public class GameScreen extends Screen {
                             destroyVerticalValue = i;
                             destroyShipHorizonalValue = j;
                             recyclable.add(bullet);
-							Item item = new Item(false,false,false);
-							item.itemActivate();
+							item = new Item(false, false, false);
+							dropItem();
                             if (item.isGhostAction) {
                                 isGhostOn = true;
                                 this.ship.setColor(Color.DARK_GRAY);
@@ -341,6 +343,12 @@ public class GameScreen extends Screen {
 			}
 		this.bullets.removeAll(recyclable);
 		BulletPool.recycle(recyclable);
+	}
+
+	private void dropItem() {
+		if(Math.random() < 0.99){
+			item.itemActivate();
+		}
 	}
 
 	private void operateLineBomb(EnemyShip enemyShip, int column, int row , Set<Bullet> recyclable, Bullet bullet) {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -307,7 +307,7 @@ public class GameScreen extends Screen {
                             destroyVerticalValue = i;
                             destroyShipHorizonalValue = j;
                             recyclable.add(bullet);
-							item = new Item(false, false, false);
+							item = new Item();
 							dropItem();
                             if (item.isGhostAction) {
                                 isGhostOn = true;

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -68,8 +68,6 @@ public class GameScreen extends Screen {
 	/** Checks if a bonus life is received. */
 	private boolean bonusLife;
 
-	private Item item = new Item();
-
 	private boolean isGhostOn = false;
 
 	private boolean isMultiShotOn = false;
@@ -307,7 +305,8 @@ public class GameScreen extends Screen {
                             destroyVerticalValue = i;
                             destroyShipHorizonalValue = j;
                             recyclable.add(bullet);
-                            item.itemActivate();
+							Item item = new Item(false,false,false);
+							item.itemActivate();
                             if (item.isGhostAction) {
                                 isGhostOn = true;
                                 this.ship.setColor(Color.DARK_GRAY);


### PR DESCRIPTION
기존의 코드에서 linebomb이 계속해서 실행된다는 문제점이 있어서 이를 수정하고자 Item 객체의 생성 방식을 변경해보았습니다.

1.  GameScreen클래스에 dropItem 메서드를 만들었습니다. 
    일정한 확률에 따라서 Item 클래스를 생성하고 true/false를 반환합니다

2. Item 클래스의 생성자를 만들었습니다. 각각의 아이템이 발동되는 조건인 isGhostAction, isMultiShotActivated 등등의 변수를 
   생성 시점부터 false로 설정하여 충돌을 없앴습니다.

3. Item 객체가 생성되면 기존에 있던 itemActivate() 메서드가 실행되며 아이템이 하나씩 발동됩니다.

4. Item 객체가 생성되지 않으면 break(332번째 줄) 를 통해 아이템이 발동되지 않습니다.
