### PR TITLE
Add timestop item with new latest code

### DIFF
--- a/src/engine/ItemManager.java
+++ b/src/engine/ItemManager.java
@@ -17,7 +17,7 @@ public class ItemManager {
 
     private ItemType itemType;
     private boolean GoastActive;
-    private boolean timeStop;
+    private boolean timeStopActive;
     private int shotNum;
     private Random rand;
 
@@ -87,11 +87,11 @@ public class ItemManager {
     }
 
     public void operateTimeStop() {
-        this.timeStop = true;
+        this.timeStopActive = true;
         new Thread(() -> {
             try {
                 Thread.sleep(4000);
-                this.timeStop = false;
+                this.timeStopActive = false;
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
@@ -112,7 +112,7 @@ public class ItemManager {
         return GoastActive;
     }
 
-    public boolean getTimeStop() {
-        return timeStop;
+    public boolean isTimeStopActive() {
+        return timeStopActive;
     }
 }

--- a/src/engine/ItemManager.java
+++ b/src/engine/ItemManager.java
@@ -17,6 +17,7 @@ public class ItemManager {
 
     private ItemType itemType;
     private boolean GoastActive;
+    private boolean timeStop;
     private int shotNum;
     private Random rand;
 
@@ -85,7 +86,17 @@ public class ItemManager {
         }).start();
     }
 
-    public void operateTimeStop() {}
+    public void operateTimeStop() {
+        this.timeStop = true;
+        new Thread(() -> {
+            try {
+                Thread.sleep(4000);
+                this.timeStop = false;
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }).start();
+    }
 
     public void operateMultiShot() {
         if (this.shotNum < 3) {
@@ -99,5 +110,9 @@ public class ItemManager {
 
     public boolean isGoastActive() {
         return GoastActive;
+    }
+
+    public boolean getTimeStop() {
+        return timeStop;
     }
 }

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -195,9 +195,14 @@ public class GameScreen extends Screen {
 				this.logger.info("The special ship has escaped");
 			}
 
-			this.ship.update();
-			this.enemyShipFormation.update();
-			this.enemyShipFormation.shoot(this.bullets);
+			if (itemManager.getTimeStop()) {
+				this.ship.update();
+			}
+			else {
+				this.ship.update();
+				this.enemyShipFormation.update();
+				this.enemyShipFormation.shoot(this.bullets);
+			}
 		}
 
 		manageCollisions();

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -195,7 +195,7 @@ public class GameScreen extends Screen {
 				this.logger.info("The special ship has escaped");
 			}
 
-			if (itemManager.getTimeStop()) {
+			if (itemManager.isTimeStopActive()) {
 				this.ship.update();
 			}
 			else {


### PR DESCRIPTION
feat: Add timestop item

refactor: Delete the contents of the master branch

When TimeStop is activated, the 'update' method in the GameScreen class is designed to update only the player's ships.

Added the 'getTimeStop' method in ItemManager class to adjust the value of the 'timeStop' variable.

The bug I mentioned in the previous commit doesn't seem to appear now.
(A bug that ends the round before all enemy ships are destroyed)